### PR TITLE
added config/maps cmd line args,

### DIFF
--- a/config/enml.lua
+++ b/config/enml.lua
@@ -331,6 +331,13 @@ if RobotConfig.name=="Cobot4" then
   enml.num_threads = 4;
 end
 
+if RobotConfig.name=="airsim" then
+  enml.map_name = "Airsim-Neighborhood";
+  enml.starting_loc_x = 0;
+  enml.starting_loc_y = 0;
+  enml.starting_angle = deg2rad(0.0);
+end
+
 -- Parameters for probabilistic object maps.
 ProbabilisticObjectMaps = {
   object_distance_threshold = 0.03;

--- a/src/add_initialization.cpp
+++ b/src/add_initialization.cpp
@@ -74,7 +74,7 @@ void ProcessBagFile(const string& in_file,
   out_bag.open(out_file.c_str(), rosbag::bagmode::Write);
 
   bool written_init = false;
-  for(rosbag::MessageInstance const m : rosbag::View(in_bag)) {
+  for(rosbag::MessageInstance const& m : rosbag::View(in_bag)) {
     if (!written_init) {
       const auto init_msg = InitMsg(x, y, theta, m.getTime());
       out_bag.write("/initialpose", m.getTime(), init_msg);

--- a/src/non_markov_localization_main.cpp
+++ b/src/non_markov_localization_main.cpp
@@ -96,7 +96,6 @@ using namespace geometry;
 using namespace math_util;
 
 typedef KDNodeValue<float, 2> KDNodeValue2f;
-std::string enml_pkg_path = ros::package::getPath("enml");
 
 namespace {
 // Name of the topic that scan data is published on.
@@ -108,9 +107,6 @@ CONFIG_STRING(odom_topic, "RobotConfig.odometry_topic");
 // Name of the topic that location reset commands are published on.
 CONFIG_STRING(initialpose_topic, "RobotConfig.initialpose_topic");
 
-// The name of the robot config file.
-string robot_config_file_ = enml_pkg_path + "/config/robot.lua";
-
 // ROS message for publishing SE(2) pose with map name.
 amrl_msgs::Localization2DMsg localization_msg_;
 
@@ -119,7 +115,6 @@ amrl_msgs::VisualizationMsg visualization_msg_;
 
 util_random::Random rand_;
 }  // namespace
-
 
 
 // Name of the map to localize the robot on.
@@ -146,7 +141,13 @@ float kMaxOdometryDeltaAngle = DegToRad(15.0);
 pthread_mutex_t relocalization_mutex_ = PTHREAD_MUTEX_INITIALIZER;
 
 // The directory where all the maps are stored.
-static const string kMapsDirectory(enml_pkg_path+"/maps");
+const char* maps_dir_ = "maps";
+
+// Directory containing all config files, including `common.lua` and `enml.lua`
+const char* config_dir_ = "config";
+
+// name of the robot configuration file in config_dir_ to use
+const char* robot_config_ = "robot.lua";
 
 // Index of test set. This will determine which file the results of the test are
 // saved to.
@@ -183,7 +184,7 @@ ros::Publisher localization_publisher_;
 NonMarkovLocalization::LocalizationOptions localization_options_;
 
 // Main class instance for Non-Markov Localization.
-NonMarkovLocalization localization_(kMapsDirectory);
+NonMarkovLocalization* localization_;
 
 // The last observed laser scan, used for auto localization.
 sensor_msgs::LaserScan last_laser_scan_;
@@ -260,13 +261,13 @@ void PublishLocation(
 }
 
 void PublishLocation() {
-  Pose2Df pose = localization_.GetLatestPose();
-  const string map = localization_.GetCurrentMapName();
+  Pose2Df pose = localization_->GetLatestPose();
+  const string map = localization_->GetCurrentMapName();
   PublishLocation(map, pose.translation.x(), pose.translation.y(), pose.angle);
 }
 
 void PublishTrace() {
-  Pose2Df latest_pose = localization_.GetLatestPose();
+  Pose2Df latest_pose = localization_->GetLatestPose();
   static vector<Vector2f> trace;
   static Vector2f lastLoc;
   static bool initialized = false;
@@ -388,12 +389,10 @@ bool LoadConfiguration(NonMarkovLocalization::LocalizationOptions* options) {
   ENML_FLOAT_CONFIG(max_update_period);
   ENML_STRING_CONFIG(map_name);
   config_reader::ConfigReader reader({
-      enml_pkg_path + "/config/common.lua",
-      robot_config_file_,
-      enml_pkg_path + "/config/enml.lua"});
-  options->minimum_node_translation = CONFIG_min_translation;
-  options->minimum_node_rotation = CONFIG_min_rotation;
-  options->max_update_period = CONFIG_max_update_period;
+    std::string(config_dir_) + "/common.lua",
+    std::string(config_dir_) + "/" + std::string(robot_config_),
+    std::string(config_dir_) + "/enml.lua"
+  });
   options->kMinRange = CONFIG_min_point_cloud_range;
   options->kMaxRange = CONFIG_max_point_cloud_range;
   options->kMaxPointToLineDistance = CONFIG_max_point_to_line_distance;
@@ -495,7 +494,7 @@ void SaveStfs(
   ScopedFile fid(stfs_file, "w");
   fprintf(fid(), "%s\n", map_name.c_str());
   fprintf(fid(), "%lf\n", timestamp);
-  VectorMap map(kMapsDirectory + "/" + map_name + ".txt");
+  VectorMap map(std::string(maps_dir_) + "/" + map_name + ".txt");
   if (kDisplaySteps) {
     visualization::ClearVisualizationMsg(visualization_msg_);
     nonblock(true);
@@ -570,7 +569,7 @@ void SaveEpisodeStats(FILE* fid) {
   vector<uint64_t> pose_ids;
   vector<vector<NonMarkovLocalization::ObservationType> > observation_classes;
   Pose2Df latest_pose;
-  if (!localization_.GetNodeData(
+  if (!localization_->GetNodeData(
           &poses,
           &pose_ids,
           &point_clouds,
@@ -582,7 +581,7 @@ void SaveEpisodeStats(FILE* fid) {
      ) {
     return;
   }
-  const string map_name = localization_.GetCurrentMapName();
+  const string map_name = localization_->GetCurrentMapName();
   int num_ltfs = 0;
   int num_stfs = 0;
   int num_dfs = 0;
@@ -953,7 +952,7 @@ void DrawLtfs(
         localization_options_.sensor_offset.x(),
       localization_options_.sensor_offset.y());
     static VectorMap map_;
-    map_.Load(localization_.GetCurrentMapName());
+    map_.Load(localization_->GetCurrentMapName());
     for (size_t i = start_pose; i <= end_pose; ++i) {
     // for (size_t i = start_pose; i <= start_pose; ++i) {
       const Vector2f pose_location(poses[3 * i + 0], poses[3 * i + 1]);
@@ -1206,7 +1205,7 @@ void CorrespondenceCallback(
   CHECK_EQ(point_clouds.size(), point_line_correspondences.size());
   ClearDisplay();
   if (!run_) {
-    localization_.Terminate();
+    localization_->Terminate();
   }
   if (debug_level_ >= 1) {
     PublishTrace();
@@ -1266,7 +1265,7 @@ void SaveSensorErrors(
     const vector<PointCloudf>& point_clouds,
     const vector<vector<NonMarkovLocalization::ObservationType> >&
         classifications) {
-  VectorMap map(kMapsDirectory + "/" + kMapName + ".txt");
+  VectorMap map(std::string(maps_dir_) + "/" + kMapName + ".txt");
   ScopedFile fid("results/sensor_errors.txt", "w");
   printf("Saving sensor errors... ");
   fflush(stdout);
@@ -1335,7 +1334,7 @@ void StandardOdometryCallback(const nav_msgs::Odometry& last_odometry_msg,
                     &(p_delta.y()),
                     &(d_theta));
   }
-  localization_.OdometryUpdate(
+  localization_->OdometryUpdate(
       kOdometryTranslationScale * p_delta.x(),
       kOdometryTranslationScale * p_delta.y(), d_theta);
   PublishLocation();
@@ -1385,7 +1384,7 @@ void LaserCallback(const sensor_msgs::LaserScan& laser_message) {
     if (debug_level_ > 1) {
       printf("Sensor update, t=%f\n", laser_message.header.stamp.toSec());
     }
-    localization_.SensorUpdate(point_cloud, normal_cloud);
+    localization_->SensorUpdate(point_cloud, normal_cloud);
   }
   last_laser_scan_ = laser_message;
 }
@@ -1459,7 +1458,7 @@ void SRLVisualize(
   vector<double> pose_weights(num_samples);
   for (size_t i = 0; i < num_samples; ++i) {
     const Pose2Df pose(poses[3 * i + 2], poses[3 * i + 0], poses[3 * i + 1]);
-    pose_weights[i] = localization_.ObservationLikelihood(
+    pose_weights[i] = localization_->ObservationLikelihood(
         pose, point_cloud_e, normal_cloud);
     if (pose_weights[i] > max_weight) {
       max_weight = pose_weights[i];
@@ -1528,7 +1527,7 @@ void SensorResettingResample(const sensor_msgs::LaserScan& laser_message) {
   static const float kAngularStdDev = DegToRad(20.0);
   printf("Running SRL...");
   fflush(stdout);
-  localization_.SensorResettingResample(
+  localization_->SensorResettingResample(
       point_cloud, normal_cloud, kNumSamples, kRadialStdDev,
       kTangentialStdDev, kAngularStdDev, &SRLVisualize, &poses, &pose_weights,
       &constraints);
@@ -1584,8 +1583,8 @@ void PlayBagFile(const string& bag_file,
   localization_options_.log_poses = true;
   localization_options_.CorrespondenceCallback =
       ((debug_level_ > 0) ? CorrespondenceCallback : NULL);
-  localization_.SetOptions(localization_options_);
-  localization_.Initialize(Pose2Df(kStartingAngle, kStartingLocation),
+  localization_->SetOptions(localization_options_);
+  localization_->Initialize(Pose2Df(kStartingAngle, kStartingLocation),
                            kMapName);
 
   rosbag::Bag bag;
@@ -1630,7 +1629,7 @@ void PlayBagFile(const string& bag_file,
       const float ss = fmod(elapsed_time, 60.0);
       if (false) {
         printf("\r%02d:%02d:%04.1f (%.1f) Lost:%.3f",
-              hh, mm, ss, elapsed_time, localization_.GetLostMetric());
+              hh, mm, ss, elapsed_time, localization_->GetLostMetric());
       }
       printf("\r%02d:%02d:%04.1f (%.1f) Pose:%8.3f,%8.3f,%6.2f\u00b0",
              hh, mm, ss, elapsed_time,
@@ -1677,12 +1676,12 @@ void PlayBagFile(const string& bag_file,
           message.getTopic() == CONFIG_scan_topic) {
         ++num_laser_scans;
         LaserCallback(*laser_message);
-        while(localization_.RunningSolver()) {
+        while(localization_->RunningSolver()) {
           Sleep(0.01);
         }
         last_laser_scan = *laser_message;
-        last_laser_pose = localization_.GetLatestPose();
-        pose_trajectory.push_back(localization_.GetLatestPose());
+        last_laser_pose = localization_->GetLatestPose();
+        pose_trajectory.push_back(localization_->GetLatestPose());
         PublishLocation();
         continue;
       }
@@ -1716,15 +1715,15 @@ void PlayBagFile(const string& bag_file,
         }
         const Pose2Df init_pose(init_angle, init_location.x(),
                                 init_location.y());
-        localization_.Initialize(init_pose, init_map);
+        localization_->Initialize(init_pose, init_map);
       }
     }
   }
-  localization_.Finalize();
+  localization_->Finalize();
   const double process_time = GetMonotonicTime() - t_start;
   const double bag_duration = bag_time - bag_time_start;
-  const vector<Pose2Df> logged_poses = localization_.GetLoggedPoses();
-  const vector<int> episode_lengths = localization_.GetLoggedEpisodeLengths();
+  const vector<Pose2Df> logged_poses = localization_->GetLoggedPoses();
+  const vector<int> episode_lengths = localization_->GetLoggedEpisodeLengths();
   printf("Done in %.3fs, bag time %.3fs (%.3fx).\n",
         process_time, bag_duration, bag_duration / process_time);
   printf("%d laser scans, %lu logged poses\n",
@@ -1753,7 +1752,7 @@ void InitializeCallback(const amrl_msgs::Localization2DMsg& msg) {
     printf("Initialize %s %f,%f %f\u00b0\n",
         msg.map.c_str(), msg.pose.x, msg.pose.y, RadToDeg(msg.pose.theta));
   }
-  localization_.Initialize(
+  localization_->Initialize(
       Pose2Df(msg.pose.theta, Vector2f(msg.pose.x, msg.pose.y)), msg.map);
   localization_publisher_.publish(msg);
 }
@@ -1764,8 +1763,8 @@ void OnlineLocalize(bool use_point_constraints, ros::NodeHandle* node) {
   localization_options_.log_poses = true;
   localization_options_.CorrespondenceCallback =
       ((debug_level_ > 0) ? CorrespondenceCallback : NULL);
-  localization_.SetOptions(localization_options_);
-  localization_.Initialize(Pose2Df(kStartingAngle, kStartingLocation),
+  localization_->SetOptions(localization_options_);
+  localization_->Initialize(Pose2Df(kStartingAngle, kStartingLocation),
                            kMapName);
 
   Subscriber laser_subscriber =
@@ -1823,6 +1822,8 @@ int main(int argc, char** argv) {
   signal(SIGALRM,HandleStop);
   google::InitGoogleLogging(argv[0]);
   google::LogToStderr();
+  // gflags::ParseCommandLineFlags(&argc, &argv, true);
+
   // CHECK(signal(SIGSEGV, &SegfaultHandler) != SIG_ERR);
 
   char* bag_file = NULL;
@@ -1834,7 +1835,12 @@ int main(int argc, char** argv) {
   bool return_initial_poses = false;
   char* robot_config_opt = NULL;
 
+
+
   static struct poptOption options[] = {
+    { "config_dir", 'c', POPT_ARG_STRING, &config_dir_, 1, "Config directory", "STRING"},
+    { "robot_config", 'r', POPT_ARG_STRING, &robot_config_, 1, "Robot configuration file", "STRING"},
+    { "maps_dir", 'm', POPT_ARG_STRING, &maps_dir_, 1, "Maps directory", "STRING"},
     { "debug" , 'd', POPT_ARG_INT, &debug_level_, 1, "Debug level", "NUM" },
     { "bag-file", 'b', POPT_ARG_STRING, &bag_file, 1, "ROS bagfile to use",
         "STRING"},
@@ -1871,11 +1877,8 @@ int main(int argc, char** argv) {
   int c;
   while((c = popt.getNextOpt()) >= 0){
   }
-
-  if (robot_config_opt) {
-    robot_config_file_ = robot_config_opt;
-    printf("Using %s for robot config.\n", robot_config_file_.c_str());
-  }
+  
+  localization_ = new NonMarkovLocalization(maps_dir_);
   CHECK(LoadConfiguration(&localization_options_));
 
   // if (bag_file == NULL) unique_node_name = true;
@@ -1910,5 +1913,7 @@ int main(int argc, char** argv) {
   } else {
     OnlineLocalize(!disable_stfs, &ros_node);
   }
+
+  delete localization_;
   return 0;
 }

--- a/src/vector_map/vector_map.cc
+++ b/src/vector_map/vector_map.cc
@@ -290,7 +290,6 @@ void VectorMap::RayCast(const Vector2f& loc,
     int iidx;
     RayCastRay(const Vector2f& ray_end, int iidx) :
         ray_end(ray_end), iidx(iidx) {}
-    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   };
   // Go through all lines, and check for intersection of rays.
   vector<RayCastRay> ray_cast_rays;
@@ -349,7 +348,7 @@ void VectorMap::Cleanup() {
     // Check if l1 intersects with any line in new lines.
     Vector2f p;
     bool intersection = false;
-    for (const Line2f l2 : new_lines) {
+    for (const Line2f& l2 : new_lines) {
       if (l2.Intersection(l1, &p)) {
         const Vector2f shrink = kShrinkDistance * l1.Dir();
         lines.push_back(Line2f(l1.p0, p - shrink));


### PR DESCRIPTION
 This allows for launching enml from a different working directory.

Putting this up as a pull request because I had a slight lack of confidence in the way I handled creating the `NonMarkovLocalization` instance. Specifically, I made it a pointer to allow for initializing it only after the arguments get parsed, since the maps_dir_ is taken in by the constructor.

I'm not sure if this is a "best practice", so let me know if you have an alternative suggestion (the other option that came to my mind was to initialize without a map directory, and add a setter on the `NonMarkovLocalization` for setting it after the configs are loaded. This would require removing the `const` modifier from  `maps_dir_` in `non_markov_localization.h`)