### PR TITLE
Update non_markov_localization_main.cpp

### DIFF
--- a/src/non_markov_localization_main.cpp
+++ b/src/non_markov_localization_main.cpp
@@ -276,7 +276,7 @@ geometry_msgs::PoseStamped ConvertAMRLmsgToROSmsg(const amrl_msgs::Localization2
 
 void PublishLocation(
     const string& map_name, const float x, const float y, const float angle) {
-  localization_msg_.header.stamp.fromSec(GetWallTime());
+  localization_msg_.header.stamp = ros::Time::now();
   localization_msg_.map = map_name;
   localization_msg_.pose.x = x;
   localization_msg_.pose.y = y;


### PR DESCRIPTION
Change message time from `GetWallTime()` to `ros::Time::now()`

This make interoperability with ROS simulated environments possible - e.g. the node can now be used when the `/use_sim_time` parameter is true http://wiki.ros.org/Clock and the clock timestamps will be aligned consistently. 

Is there a  downside I don't see?