### PR TITLE
Add dependabot config for submodule updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
add config file for dependabot, which will automatically create a PR whenever a submodule this code depends on is updated.
These PRs won't automatically merge, but it seems like a nice feature to automatically create these PRs so we don't go too long with out of date submodules