### PR TITLE
Adds support for users running Ceres2.x

### DIFF
--- a/src/non_markov_localization.cpp
+++ b/src/non_markov_localization.cpp
@@ -136,7 +136,6 @@ void SetSolverOptions(
   // solver_options.linear_solver_type = ceres::SPARSE_NORMAL_CHOLESKY;
   solver_options.minimizer_progress_to_stdout = false;
   solver_options.num_threads = localization_options.kNumThreads;
-  solver_options.num_linear_solver_threads = localization_options.kNumThreads;
   solver_options.max_num_iterations =
       localization_options.max_solver_iterations;
   solver_options.function_tolerance = 1e-7;
@@ -753,7 +752,6 @@ void NonMarkovLocalization::SensorResettingResample(
     solver_options.linear_solver_type = ceres::SPARSE_SCHUR;
     solver_options.minimizer_progress_to_stdout = false;
     solver_options.num_threads = localization_options_.kNumThreads;
-    solver_options.num_linear_solver_threads = localization_options_.kNumThreads;
     solver_options.max_num_iterations = 2;
     solver_options.function_tolerance = 0.001;
     // solver_options.update_state_every_iteration = true;


### PR DESCRIPTION
As of Ceres version 2, there was a breaking change that removed the `Solver::Options::num_linear_solver_threads` from their library. There does not seem to be a replacement.

This PR simply removes the reference to `Solver::Options::num_linear_solver_threads`. This allows users to use Ceres version 2.x as well as Ceres version 1.y.

You can see the Ceres changelog [here](http://ceres-solver.org/version_history.html).